### PR TITLE
Quantization Pass Bug

### DIFF
--- a/machop/chop/passes/graph/transforms/quantize/quantize.py
+++ b/machop/chop/passes/graph/transforms/quantize/quantize.py
@@ -1,6 +1,6 @@
 from copy import copy, deepcopy
 import logging
-
+import torch
 from chop.passes.graph.interface.save_and_load import load_mase_graph_interface_pass
 
 from ...utils import (
@@ -224,4 +224,7 @@ def quantize_transform_pass(graph, pass_args=None):
             graph = graph_iterator_quantize_by_regex_name(graph, pass_args)
         case _:
             raise ValueError(f'Unsupported quantize "by": {by}')
+
+    # link the model with graph
+    graph.model = torch.fx.GraphModule(graph.model, graph.fx_graph)
     return graph, {}


### PR DESCRIPTION
For this bug, it might happen anywhere when we are trying to modify the `call_func` or `call_method` attribute of fx_graph, so it might not only in the quantization pass, 
I only relinked the quantization pass. I don't know if there is some other place need to be relinked. I've considered relink the whole transform pass, but if relink them all , some places  (search) only call the quantizaition pass will still be broken.