### PR TITLE
Suggestion: Add a nix derivation for better environment reproducibility

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ with import <nixpkgs>{
 
 let
   pythonPackages = pkgs.python3Packages;
+  MACHOP_DIR = builtins.toString ./machop;
 in pkgs.mkShell {
 
   LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.clangStdenv.cc.cc pkgs.libGL pkgs.glib cudaPackages.cuda_cudart cudaPackages.cudatoolkit cudaPackages.cudnn ];
@@ -19,12 +20,7 @@ in pkgs.mkShell {
     # dropping into the shell
     pythonPackages.venvShellHook
 
-    # Those are dependencies that we would like to use from nixpkgs, which will
-    # add them to PYTHONPATH and thus make them accessible from within the venv.
-    # pythonPackages.numpy
-    # pythonPackages.requests
-
-    # In this particular example, in order to compile any binary extensions they may
+    # For MASE, in order to compile some binary extensions they may
     # require, the Python modules listed in the requirements.txt need
     # the following packages to be installed locally:
     taglib
@@ -76,7 +72,7 @@ in pkgs.mkShell {
     unset SOURCE_DATE_EPOCH
 
     # Add macho to the users PYTHONPATH
-    export PYTHONPATH="$PYTHONPATH:/home/jlsand/mase_group7/machop"
+    export PYTHONPATH="$PYTHONPATH:${MACHOP_DIR}"
 
     export CUDA_PATH=${pkgs.cudatoolkit}
     # Enter terminal shell of your choice e.g. fish or bash

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,85 @@
+with import <nixpkgs>{
+  config.allowUnfree = true;  
+};
+
+let
+  pythonPackages = pkgs.python3Packages;
+in pkgs.mkShell {
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.clangStdenv.cc.cc pkgs.libGL pkgs.glib cudaPackages.cuda_cudart cudaPackages.cudatoolkit cudaPackages.cudnn ];
+
+  name = "impureMaseEnv";
+  venvDir = "./.venv";
+  buildInputs = [
+    # A Python interpreter including the 'venv' module is required to bootstrap
+    # the environment.
+    pythonPackages.python
+
+    # This executes some shell code to initialize a venv in $venvDir before
+    # dropping into the shell
+    pythonPackages.venvShellHook
+
+    # Those are dependencies that we would like to use from nixpkgs, which will
+    # add them to PYTHONPATH and thus make them accessible from within the venv.
+    # pythonPackages.numpy
+    # pythonPackages.requests
+
+    # In this particular example, in order to compile any binary extensions they may
+    # require, the Python modules listed in the requirements.txt need
+    # the following packages to be installed locally:
+    taglib
+    openssl
+    git
+    libxml2
+    libxslt
+    libzip
+    zlib
+    libGL
+    glib
+    libglvnd
+    mesa
+
+    python311Packages.cocotb-bus
+    python311Packages.cocotb    
+    python311Packages.pyopengl
+    wget
+    python311Packages.tensorboard
+    # python311Packages.tensorflowWithCuda
+    python311Packages.tensorflow-bin
+    python311Packages.torch-bin
+    python311Packages.torchvision-bin
+    python311Packages.torchaudio-bin
+
+    cudaPackages.cuda_cudart
+    cudaPackages.cudatoolkit
+    cudaPackages.cudnn
+
+    # python311Packages.pytorch-lightning
+    python311Packages.keras
+    python311Packages.python-lsp-server
+
+	verible
+    verilator
+    svls
+  ];
+
+  # Run this command, only after creating the virtual environment
+  postVenvCreation = ''
+    unset SOURCE_DATE_EPOCH
+    TMPDIR=./tmp/ pip install -r ./machop/requirements.txt
+  '';
+
+  # Now we can execute any commands within the virtual environment.
+  # This is optional and can be left out to run pip manually.
+  postShellHook = ''
+    # allow pip to install wheels
+    unset SOURCE_DATE_EPOCH
+
+    # Add macho to the users PYTHONPATH
+    export PYTHONPATH="$PYTHONPATH:/home/jlsand/mase_group7/machop"
+
+    export CUDA_PATH=${pkgs.cudatoolkit}
+    # Enter terminal shell of your choice e.g. fish or bash
+    # fish
+  '';
+}


### PR DESCRIPTION
## Motivation
Many students had issues with wrong torch versions, CUDA not being available etc. These issues can be hard to fix depending on the local environment of the student. Additionally, these issues tend to waste a lot of time for the student and the GTA attempting to help solve it. 

As such, for future iterations of the course it might be worth including a `nix` [derivation shell](https://nixos.wiki/wiki/Development_environment_with_nix-shell) to the project for the sake of stability and reproducibility across platforms. A nix derivation would be able to explicitly state some of the system-level dependencies that some of the python packages in `requirements.txt` (implicitly) rely upon (e.g. CUDA). Additionally, one could add nix packages such as `svls` which in general would be useful when developing for MASE.

Finally, this would mean the _only_ prerequisite for getting MASE up and running would be an installation of the `nix` package manager.

## Details
A `nix` derivation would just be a `shell.nix` file in the root of the MASE repo. I wrote a derivation for myself during the course, and it served me well across 4 different machines. I have included it in this PR as an example.

To initialize the `nix` environment for mase, first install the `nix` [package manager](https://nixos.org/download/#download-nix). Then simply enter the `nix` environment by running `nix-shell` in the MASE repo directory containing the `shell.nix` file. This will enter a nix shell with:
- A fully working MASE environment initialized. 
- Ensure transitive binary requirements such as `libzip`, `libxml2` and `mesa` are installed. 
- `verible`, `verilator` and `svls` are automatically installed.
- PYTHONPATH extended with the machop directory.
- For full compatibility, a local virtual env is used to install the rest of the packages from `requirements.txt`. This means `requirements.txt` can be extended as usual and the `nix` environment will almost certainly still work.