### PR TITLE
Update config.yaml ci-rules

### DIFF
--- a/.bbx/config.yaml
+++ b/.bbx/config.yaml
@@ -1,8 +1,23 @@
+
 # Define a runner that will be used to run a job
 runners:
   ubuntu-runner:
-    image: ee-kraken:5000/ubuntu-mase-pipeline
+    image: deepwok/mase-docker-cuda:latest
 
+
+# Define a workflow to orchestrate a job
+workflows:
+  mase-chop-regression:
+    triggers:
+      - manual
+    jobs:
+      - chop-regression
+
+  mase-hw-regression:
+    triggers:
+      - manual
+    jobs:
+      - hw-regression
 # Define a job to be performed during a workflow
 jobs:
   choose-commit:
@@ -30,21 +45,3 @@ jobs:
           command: |
             python3 scripts/test-hardware.py -a
 
-
-# Define a workflow to orchestrate a job
-workflows:
-  mase-chop-regression:
-    triggers:
-      - push
-      - schedule:
-          cron: "0 2 * * *"
-    jobs:
-      - chop-regression
-
-  mase-hw-regression:
-    triggers:
-      - push
-      - schedule:
-          cron: "0 2 * * *"
-    jobs:
-      - hw-regression


### PR DESCRIPTION

Changed the trigger to manual to stop it triggering automatically and overwhelming the server. Also changed the image to the dockerhub one, since the ee-kraken registry no longer exists - the registry pod kept getting terminated on ee-kraken as ee-kraken had limited space available on the root directory of ee-kraken.