### PR TITLE
Nix shell

### DIFF
--- a/scripts/init-conda.sh
+++ b/scripts/init-conda.sh
@@ -10,7 +10,7 @@ set -o nounset
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 # create and activate mase env
-conda env create -f ${DIR}/../machop/environment.yml
+conda env create -f ${DIR}/../environment.yml
 eval "$(conda shell.bash hook)"
 conda activate mase
 
@@ -18,7 +18,7 @@ conda activate mase
 current_python=$(which python)
 if [[ ${current_python} = *"envs/mase/bin/python" ]]; then
     python -m pip install --user --upgrade pip &&
-        python -m pip install -r ${DIR}/../machop/requirements.txt
+        python -m pip install -r ${DIR}/../requirements.txt
 
     if [[ $? -eq 0 ]]; then
         echo "✅ Successfully installed all the requirements"

--- a/scripts/init-nix.sh
+++ b/scripts/init-nix.sh
@@ -3,21 +3,12 @@
 #    This script installs environment vars for the mase nix shell 
 # --------------------------------------------------------------------
 
-set -o errexit
-set -o pipefail
-set -o nounset
-
 # The absolute path to the directory of this script.
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 MASE="$(dirname "$SCRIPT_DIR")"
 
 # Basic PATH setup 
 export PATH=$MASE/scripts:$MASE/hls/build/bin:$MASE/llvm/build/bin:$MASE/mlir-aie/install/bin:$MASE/mlir-air/install/bin:$PATH
-export PYTHONPATH=$MASE:$MASE/src:$MASE/mlir-aie/install/python:$MASE/mlir-air/install/python:$PYTHONPATH
+export PYTHONPATH=$PYTHONPATH:$MASE:$MASE/src:$MASE/mlir-aie/install/python:$MASE/mlir-air/install/python
 export LIBRARY_PATH=${LIBRARY_PATH:+LIBRARY_PATH:}/usr/lib/x86_64-linux-gnu
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+LD_LIBRARY_PATH:}$MASE/mlir-aie/lib:$MASE/mlir-air/lib:/opt/xaiengine
-
-# Terminal color
-export PS1="[\\[$(tput setaf 3)\\]\t\\[$(tput setaf 2)\\] \u\\[$(tput sgr0)\\]@\\[$(tput setaf 2)\\]\h \\[$(tput setaf 7)\\]\w \\[$(tput sgr0)\\]] \\[$(tput setaf 6)\\]$ \\[$(tput sgr0)\\]"
-export LS_COLORS='rs=0:di=01;96:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01'
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$MASE/mlir-aie/lib:$MASE/mlir-air/lib:/opt/xaiengine

--- a/scripts/init-nix.sh
+++ b/scripts/init-nix.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------
+#    This script installs environment vars for the mase nix shell 
+# --------------------------------------------------------------------
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# The absolute path to the directory of this script.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+MASE="$(dirname "$SCRIPT_DIR")"
+
+# Basic PATH setup 
+export PATH=$MASE/scripts:$MASE/hls/build/bin:$MASE/llvm/build/bin:$MASE/mlir-aie/install/bin:$MASE/mlir-air/install/bin:$PATH
+export PYTHONPATH=$MASE:$MASE/src:$MASE/mlir-aie/install/python:$MASE/mlir-air/install/python:$PYTHONPATH
+export LIBRARY_PATH=${LIBRARY_PATH:+LIBRARY_PATH:}/usr/lib/x86_64-linux-gnu
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+LD_LIBRARY_PATH:}$MASE/mlir-aie/lib:$MASE/mlir-air/lib:/opt/xaiengine
+
+# Terminal color
+export PS1="[\\[$(tput setaf 3)\\]\t\\[$(tput setaf 2)\\] \u\\[$(tput sgr0)\\]@\\[$(tput setaf 2)\\]\h \\[$(tput setaf 7)\\]\w \\[$(tput sgr0)\\]] \\[$(tput setaf 6)\\]$ \\[$(tput sgr0)\\]"
+export LS_COLORS='rs=0:di=01;96:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01'

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,9 @@ requirements = [
     "pytorch-nlp",
     "datasets",
     "onnx",
-    "onnxruntime",
+    "onnxruntime>=1.16",
     "onnxruntime-tools",
+    "onnxconverter_common",
     "optimum",
     "black",
     "GitPython",
@@ -69,6 +70,7 @@ requirements = [
     "prettytable",
     "pyyaml",
     "pynvml",
+    "bitstring>=4.2",
 ]
 
 if is_cuda_available():

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,13 @@
 let
   nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-unstable";
-  pkgs = import nixpkgs { config = {}; overlays = []; };
+  pkgs = import nixpkgs { config = {allowUnfree = true;}; overlays = []; };
 in
 
 let
   pythonPackages = pkgs.python311Packages;
 in pkgs.mkShellNoCC {
   venvDir = "./.venv";
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc ];
   packages = with pkgs; [
     # Python 3.11
     pythonPackages.python
@@ -15,10 +16,15 @@ in pkgs.mkShellNoCC {
     # dropping into the shell
     # TODO: consider use setuptoolsBuildHook, as documented in https://nixos.org/manual/nixpkgs/stable/#python
     pythonPackages.venvShellHook
+    # pythonPackages.torch-bin
 
     # houskeeping 
     git
     neovim
     glib
   ];
+  postShellHook = ''
+    # install mase as a package
+    python3 -m pip install .
+  '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,24 @@
+let
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-unstable";
+  pkgs = import nixpkgs { config = {}; overlays = []; };
+in
+
+let
+  pythonPackages = pkgs.python311Packages;
+in pkgs.mkShellNoCC {
+  venvDir = "./.venv";
+  packages = with pkgs; [
+    # Python 3.11
+    pythonPackages.python
+    pythonPackages.pip
+    # This executes some shell code to initialize a venv in $venvDir before
+    # dropping into the shell
+    # TODO: consider use setuptoolsBuildHook, as documented in https://nixos.org/manual/nixpkgs/stable/#python
+    pythonPackages.venvShellHook
+
+    # houskeeping 
+    git
+    neovim
+    glib
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -39,5 +39,7 @@ in pkgs.mkShellNoCC {
   postShellHook = ''
     # install mase as a package
     python3 -m pip install .
+    # add env variables 
+    source scripts/init-nix.sh
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -38,7 +38,7 @@ in pkgs.mkShellNoCC {
   ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ verible ]);
   postShellHook = ''
     # install mase as a package
-    python3 -m pip install .
+    python3 -m pip -e install .
     # add env variables 
     source scripts/init-nix.sh
   '';

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,7 @@ in pkgs.mkShellNoCC {
     # Python 3.11
     pythonPackages.python
     pythonPackages.pip
+    pythonPackages.sphinx
     # This executes some shell code to initialize a venv in $venvDir before
     # dropping into the shell
     # TODO: consider use setuptoolsBuildHook, as documented in https://nixos.org/manual/nixpkgs/stable/#python
@@ -22,6 +23,15 @@ in pkgs.mkShellNoCC {
     git
     neovim
     glib
+    unzip
+    mesa
+    cmake
+    zsh
+
+    # hardware
+    verible
+    verilator
+    svls
   ];
   postShellHook = ''
     # install mase as a package

--- a/shell.nix
+++ b/shell.nix
@@ -29,10 +29,13 @@ in pkgs.mkShellNoCC {
     zsh
 
     # hardware
-    verible
+    # verible is only supported on Linux (x86_64-linux, i686-linux and aarch64-linux)
+    # https://search.nixos.org/packages?channel=23.11&show=verible&from=0&size=50&sort=relevance&type=packages&query=verible
+    # verible
     verilator
     svls
-  ];
+  ]
+  ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ verible ]);
   postShellHook = ''
     # install mase as a package
     python3 -m pip install .

--- a/shell.nix
+++ b/shell.nix
@@ -38,7 +38,7 @@ in pkgs.mkShellNoCC {
   ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ verible ]);
   postShellHook = ''
     # install mase as a package
-    python3 -m pip -e install .
+    python3 -m pip install -e .
     # add env variables 
     source scripts/init-nix.sh
   '';

--- a/src/chop/passes/graph/transforms/onnxrt/quantize.py
+++ b/src/chop/passes/graph/transforms/onnxrt/quantize.py
@@ -24,8 +24,8 @@ from .utils import (
 QUANT_MAP = {
     "int8": QuantType.QInt8,
     "uint8": QuantType.QUInt8,
-    "int16": QuantType.QInt16,
-    "uint16": QuantType.QUInt16,
+    # "int16": QuantType.QInt16,
+    # "uint16": QuantType.QUInt16,
 }
 
 


### PR DESCRIPTION
This is taking the suggestion from #100, but also try to make it work on non-gpu enabled machines.

Current testing (DO NOT MERGE)
- [x] darwin x86_64 mac
- [x] darwin aarch64 mac
- [x] linux x86_64 gpu-enbaled
- [x] windows x86_64

Testing flow:
Make sure `nix` is installed (https://nixos.org/download/)
Run the following command `nix-shell`

software quick test 
`python -c "import torch; print(torch.__version__, torch.__file__)"`

hardware quick test
`verilator --version`
`python src/mase_components/linear/test/test_lint_linear.py`
