### PR TITLE
fixed circular buffer for case repeat=1

### DIFF
--- a/src/mase_components/memory/rtl/repeat_circular_buffer.sv
+++ b/src/mase_components/memory/rtl/repeat_circular_buffer.sv
@@ -69,8 +69,7 @@ module repeat_circular_buffer #(
   always_comb begin
     next_self = self;
 
-    if (REPEAT==1)
-      in_ready = (self.size != SIZE);
+    if (REPEAT == 1) in_ready = (self.size != SIZE);
     else
       in_ready = (self.size != SIZE) && !(self.rep == REPEAT - 1 && self.write_ptr == self.read_ptr);
 

--- a/src/mase_components/memory/rtl/repeat_circular_buffer.sv
+++ b/src/mase_components/memory/rtl/repeat_circular_buffer.sv
@@ -69,8 +69,10 @@ module repeat_circular_buffer #(
   always_comb begin
     next_self = self;
 
-    // Input side ready
-    in_ready = (self.size != SIZE) && !(self.rep == REPEAT - 1 && self.write_ptr == self.read_ptr);
+    if (REPEAT==1)
+      in_ready = (self.size != SIZE);
+    else
+      in_ready = (self.size != SIZE) && !(self.rep == REPEAT - 1 && self.write_ptr == self.read_ptr);
 
     // Pause reading when there is (no transfer on this cycle) AND the registers are full.
     pause_reads = !out_ready && (self.out_reg.valid || self.extra_reg.valid);


### PR DESCRIPTION
Fixed the issue which caused circular buffer to not work when parameter REPEAT=1. Fixed_linear testbench should pass now for all cases 