### PR TITLE
fix tutorial2&5

### DIFF
--- a/docs/source/modules/documentation/tutorials/tutorial_2_lora_finetune.ipynb
+++ b/docs/source/modules/documentation/tutorials/tutorial_2_lora_finetune.ipynb
@@ -1141,7 +1141,10 @@
    "outputs": [],
    "source": [
     "for param in mg.model.bert.embeddings.parameters():\n",
-    "    param.requires_grad = False"
+    "    param.requires_grad = False\n",
+    "\n",
+    "for param in mg.model.bert.parameters():\n",
+    "    param.data = param.data.contiguous()"
    ]
   },
   {

--- a/src/chop/ir/graph/mase_graph.py
+++ b/src/chop/ir/graph/mase_graph.py
@@ -444,7 +444,7 @@ class MaseGraph:
 
         logger.info(f"Exporting GraphModule to {fname}.pt")
         with open(f"{fname}.pt", "wb") as f:
-            torch.save(self.model, f)
+            torch.save(self.model.state_dict(), f)
 
         logger.info(f"Exporting MaseMetadata to {fname}.mz")
 


### PR DESCRIPTION
1. In Tutorial 2: The trainer would have a problem when saving non-contiguous tensor

2. Tutorial 5: in the model export function, save model.state_dict() rather than the model