### PR TITLE
update mase/src/chop/nn/quantizers/utils.py

### DIFF
--- a/src/chop/nn/quantizers/utils.py
+++ b/src/chop/nn/quantizers/utils.py
@@ -153,9 +153,12 @@ class BinaryZeroScaled(InplaceFunction):
     """
 
     @staticmethod
-    def alpha(tensor):  # determine batch means
+    def alpha(tensor):
         absvalue = tensor.abs()
-        alpha = absvalue.mean(dim=(1, 2, 3), keepdims=True)
+
+        dims = list(range(1, tensor.ndimension()))  
+        alpha = absvalue.mean(dim=dims, keepdim=True)
+
         return alpha.view(-1, 1)
 
     @staticmethod


### PR DESCRIPTION
The tensor dimension might not match the original dim=(1, 2, 3), causing problems, so it is better to get the dimension every time